### PR TITLE
Increase controller memory limit from 96Mi to 128Mi in values-local.yaml

### DIFF
--- a/values-local.yaml
+++ b/values-local.yaml
@@ -3,7 +3,7 @@ metallb:
     resources:
       limits:
         cpu: 0m
-        memory: 96Mi
+        memory: 128Mi
       requests:
         cpu: 0m
         memory: 0Mi


### PR DESCRIPTION
- Updated resource limits for memory allocation
- Affects only local deployment configuration