### PR TITLE
Increase metallb controller memory limit to 192Mi

### DIFF
--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -3,7 +3,7 @@ metallb:
     resources:
       limits:
         cpu: 200m
-        memory: 160Mi
+        memory: 192Mi
       requests:
         cpu: 20m
         memory: 128Mi


### PR DESCRIPTION
Prevent OOMKilled events by raising headroom above the previous 160Mi cap.