### PR TITLE
Remove local controller memory limit override

### DIFF
--- a/values-local.yaml
+++ b/values-local.yaml
@@ -3,7 +3,6 @@ metallb:
     resources:
       limits:
         cpu: 0m
-        memory: 128Mi
       requests:
         cpu: 0m
         memory: 0Mi


### PR DESCRIPTION
Delete the `metallb.controller.resources.limits.memory` setting in values-local.yaml so local memory limit behavior falls back to chart defaults to avoid OOM kills.